### PR TITLE
Wishlist model test

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
     "cucumberautocomplete.strictGherkinValidation": true,
     "cucumberautocomplete.smartSnippets": true,
     "cucumberautocomplete.gherkinDefinitionPart": "@(given|when|then)\\(",
+    "cSpell.words": [
+        "sqlalchemy"
+    ],
 }
 

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -23,7 +23,7 @@ from service.common import error_handlers, cli_commands  # noqa: F401, E402
 log_handlers.init_logging(app, "gunicorn.error")
 
 app.logger.info(70 * "*")
-app.logger.info("  S E R V I C E   R U N N I N G  ".center(70, "*"))
+app.logger.info("  W I S H L I S T   S E R V I C E   R U N N I N G  ".center(70, "*"))
 app.logger.info(70 * "*")
 
 try:

--- a/service/models.py
+++ b/service/models.py
@@ -33,7 +33,7 @@ class PersistentBase:
     """
 
     def __init__(self):
-        self.id = None  # pylint: disable=invalid-name
+        self.wishlist_id = None  # pylint: disable=invalid-name
 
     @abstractmethod
     def serialize(self) -> dict:
@@ -48,7 +48,7 @@ class PersistentBase:
         Creates a Wishlist to the database
         """
         logger.info("Creating %s", self.wishlist_id)
-        self.id = None  # pylint: disable=invalid-name
+        self.wishlist_id = None  # pylint: disable=invalid-name
         # id must be none to generate next primary key
         db.session.add(self)
         db.session.commit()
@@ -107,16 +107,6 @@ class Wishlist(db.Model, PersistentBase):
 
     def __repr__(self):
         return f"<wishlist_id=[{self.wishlist_id}]>"
-
-    def create(self):
-        """
-        Creates a Wishlist to the database
-        """
-        logger.info("Creating %s", self.wishlist_id)
-        self.wishlist_id = None  # pylint: disable=invalid-name
-        # id must be none to generate next primary key
-        db.session.add(self)
-        db.session.commit()
 
     def serialize(self):
         """Converts an Wishlist into a dictionary"""

--- a/service/models.py
+++ b/service/models.py
@@ -108,6 +108,16 @@ class Wishlist(db.Model, PersistentBase):
     def __repr__(self):
         return f"<wishlist_id=[{self.wishlist_id}]>"
 
+    def create(self):
+        """
+        Creates a Wishlist to the database
+        """
+        logger.info("Creating %s", self.wishlist_id)
+        self.wishlist_id = None  # pylint: disable=invalid-name
+        # id must be none to generate next primary key
+        db.session.add(self)
+        db.session.commit()
+
     def serialize(self):
         """Converts an Wishlist into a dictionary"""
         wishlist = {

--- a/service/models.py
+++ b/service/models.py
@@ -106,8 +106,8 @@ class Wishlist(db.Model, PersistentBase):
     created_date = db.Column(db.Date(), nullable=False, default=date.today())
 
     def __repr__(self):
-        return f"<Wishlist id=[{self.id}]>"
-    
+        return f"<wishlist_id=[{self.wishlist_id}]>"
+
     def serialize(self):
         """Converts an Wishlist into a dictionary"""
         wishlist = {
@@ -119,21 +119,21 @@ class Wishlist(db.Model, PersistentBase):
         return wishlist
 
     def deserialize(self, data):
-            """
-            Populates an Wishlist from a dictionary
+        """
+        Populates an Wishlist from a dictionary
 
-            Args:
-                data (dict): A dictionary containing the resource data
-            """
-            try:
-                self.customer_id = data["customer_id"]
-                self.wishlist_name = data["wishlist_name"]
-                self.created_date = date.fromisoformat(data["created_date"])
-            except KeyError as error:
-                raise DataValidationError("Invalid Wishlist: missing " + error.args[0]) from error
-            except TypeError as error:
-                raise DataValidationError(
-                    "Invalid Wishlist: body of request contained "
-                    "bad or no data - " + error.args[0]
-                ) from error
-            return self
+        Args:
+            data (dict): A dictionary containing the resource data
+        """
+        try:
+            self.customer_id = data["customer_id"]
+            self.wishlist_name = data["wishlist_name"]
+            self.created_date = date.fromisoformat(data["created_date"])
+        except KeyError as error:
+            raise DataValidationError("Invalid Wishlist: missing " + error.args[0]) from error
+        except TypeError as error:
+            raise DataValidationError(
+                "Invalid Wishlist: body of request contained "
+                "bad or no data - " + error.args[0]
+            ) from error
+        return self

--- a/service/models.py
+++ b/service/models.py
@@ -102,6 +102,7 @@ class Wishlist(db.Model, PersistentBase):
     # Table Schema
     wishlist_id = db.Column(db.Integer, primary_key=True)
     customer_id = db.Column(db.Integer)
+    wishlist_name = db.Column(db.String(64))  # e.g., work, home, vacation, etc.
     created_date = db.Column(db.Date(), nullable=False, default=date.today())
 
     def __repr__(self):
@@ -112,6 +113,7 @@ class Wishlist(db.Model, PersistentBase):
         wishlist = {
             "wishlist_id": self.wishlist_id,
             "customer_id": self.customer_id,
+            "wishlist_name": self.wishlist_name,
             "created_date": self.created_date.isoformat(),
         }
         return wishlist
@@ -125,6 +127,7 @@ class Wishlist(db.Model, PersistentBase):
             """
             try:
                 self.customer_id = data["customer_id"]
+                self.wishlist_name = data["wishlist_name"]
                 self.created_date = date.fromisoformat(data["created_date"])
             except KeyError as error:
                 raise DataValidationError("Invalid Wishlist: missing " + error.args[0]) from error

--- a/service/models.py
+++ b/service/models.py
@@ -127,7 +127,7 @@ class Wishlist(db.Model, PersistentBase):
                 self.customer_id = data["customer_id"]
                 self.created_date = date.fromisoformat(data["created_date"])
             except KeyError as error:
-                raise DataValidationError("Invalid Account: missing " + error.args[0]) from error
+                raise DataValidationError("Invalid Wishlist: missing " + error.args[0]) from error
             except TypeError as error:
                 raise DataValidationError(
                     "Invalid Wishlist: body of request contained "

--- a/service/models.py
+++ b/service/models.py
@@ -1,9 +1,11 @@
 """
-Models for YourResourceModel
+Models for Wishlist
 
 All of the models are stored in this module
 """
 import logging
+from datetime import date
+from abc import abstractmethod
 from flask_sqlalchemy import SQLAlchemy
 
 logger = logging.getLogger("flask.app")
@@ -15,72 +17,54 @@ db = SQLAlchemy()
 # Function to initialize the database
 def init_db(app):
     """ Initializes the SQLAlchemy app """
-    YourResourceModel.init_db(app)
+    Wishlist.init_db(app)
 
 
 class DataValidationError(Exception):
     """ Used for an data validation errors when deserializing """
 
 
-class YourResourceModel(db.Model):
+######################################################################
+#  P E R S I S T E N T   B A S E   M O D E L
+######################################################################
+class PersistentBase:
     """
-    Class that represents a YourResourceModel
+    Base class for persistent models
     """
 
-    app = None
+    def __init__(self):
+        self.id = None  # pylint: disable=invalid-name
 
-    # Table Schema
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(63))
+    @abstractmethod
+    def serialize(self) -> dict:
+        """Convert an object into a dictionary"""
 
-    def __repr__(self):
-        return f"<YourResourceModel {self.name} id=[{self.id}]>"
+    @abstractmethod
+    def deserialize(self, data: dict) -> None:
+        """Convert a dictionary into an object"""
 
     def create(self):
         """
-        Creates a YourResourceModel to the database
+        Creates a Wishlist to the database
         """
         logger.info("Creating %s", self.name)
         self.id = None  # pylint: disable=invalid-name
+        # id must be none to generate next primary key
         db.session.add(self)
         db.session.commit()
 
     def update(self):
         """
-        Updates a YourResourceModel to the database
+        Updates a Wishlist to the database
         """
         logger.info("Saving %s", self.name)
         db.session.commit()
 
     def delete(self):
-        """ Removes a YourResourceModel from the data store """
+        """ Removes a Wishlist from the data store """
         logger.info("Deleting %s", self.name)
         db.session.delete(self)
         db.session.commit()
-
-    def serialize(self):
-        """ Serializes a YourResourceModel into a dictionary """
-        return {"id": self.id, "name": self.name}
-
-    def deserialize(self, data):
-        """
-        Deserializes a YourResourceModel from a dictionary
-
-        Args:
-            data (dict): A dictionary containing the resource data
-        """
-        try:
-            self.name = data["name"]
-        except KeyError as error:
-            raise DataValidationError(
-                "Invalid YourResourceModel: missing " + error.args[0]
-            ) from error
-        except TypeError as error:
-            raise DataValidationError(
-                "Invalid YourResourceModel: body of request contained bad or no data - "
-                "Error message: " + error
-            ) from error
-        return self
 
     @classmethod
     def init_db(cls, app):
@@ -94,22 +78,59 @@ class YourResourceModel(db.Model):
 
     @classmethod
     def all(cls):
-        """ Returns all of the YourResourceModels in the database """
-        logger.info("Processing all YourResourceModels")
+        """ Returns all of the Wishlists in the database """
+        logger.info("Processing all Wishlists")
         return cls.query.all()
 
     @classmethod
     def find(cls, by_id):
-        """ Finds a YourResourceModel by it's ID """
+        """ Finds a Wishlist by it's ID """
         logger.info("Processing lookup for id %s ...", by_id)
         return cls.query.get(by_id)
 
-    @classmethod
-    def find_by_name(cls, name):
-        """Returns all YourResourceModels with the given name
 
-        Args:
-            name (string): the name of the YourResourceModels you want to match
-        """
-        logger.info("Processing name query for %s ...", name)
-        return cls.query.filter(cls.name == name)
+######################################################################
+#  W I S H L I S T   M O D E L
+######################################################################
+class Wishlist(db.Model, PersistentBase):
+    """
+    Class that represents a Wishlist
+    """
+
+    app = None
+
+    # Table Schema
+    wishlist_id = db.Column(db.Integer, primary_key=True)
+    customer_id = db.Column(db.Integer)
+    created_date = db.Column(db.Date(), nullable=False, default=date.today())
+
+    def __repr__(self):
+        return f"<Wishlist {self.name} id=[{self.id}]>"
+    
+    def serialize(self):
+        """Converts an Wishlist into a dictionary"""
+        wishlist = {
+            "wishlist_id": self.wishlist_id,
+            "customer_id": self.customer_id,
+            "created_date": self.created_date.isoformat(),
+        }
+        return wishlist
+
+    def deserialize(self, data):
+            """
+            Populates an Wishlist from a dictionary
+
+            Args:
+                data (dict): A dictionary containing the resource data
+            """
+            try:
+                self.customer_id = data["customer_id"]
+                self.created_date = date.fromisoformat(data["created_date"])
+            except KeyError as error:
+                raise DataValidationError("Invalid Account: missing " + error.args[0]) from error
+            except TypeError as error:
+                raise DataValidationError(
+                    "Invalid Wishlist: body of request contained "
+                    "bad or no data - " + error.args[0]
+                ) from error
+            return self

--- a/service/models.py
+++ b/service/models.py
@@ -47,7 +47,7 @@ class PersistentBase:
         """
         Creates a Wishlist to the database
         """
-        logger.info("Creating %s", self.name)
+        logger.info("Creating %s", self.wishlist_id)
         self.id = None  # pylint: disable=invalid-name
         # id must be none to generate next primary key
         db.session.add(self)
@@ -57,12 +57,12 @@ class PersistentBase:
         """
         Updates a Wishlist to the database
         """
-        logger.info("Saving %s", self.name)
+        logger.info("Saving %s", self.wishlist_id)
         db.session.commit()
 
     def delete(self):
         """ Removes a Wishlist from the data store """
-        logger.info("Deleting %s", self.name)
+        logger.info("Deleting %s", self.wishlist_id)
         db.session.delete(self)
         db.session.commit()
 
@@ -105,7 +105,7 @@ class Wishlist(db.Model, PersistentBase):
     created_date = db.Column(db.Date(), nullable=False, default=date.today())
 
     def __repr__(self):
-        return f"<Wishlist {self.name} id=[{self.id}]>"
+        return f"<Wishlist id=[{self.id}]>"
     
     def serialize(self):
         """Converts an Wishlist into a dictionary"""

--- a/service/routes.py
+++ b/service/routes.py
@@ -1,12 +1,12 @@
 """
-My Service
+Wishlist
 
 Describe what your service does here
 """
 
 from flask import jsonify, request, url_for, abort
 from service.common import status  # HTTP Status Codes
-from service.models import YourResourceModel
+from service.models import Wishlist
 
 # Import Flask application
 from . import app

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,21 @@
+"""
+Test Factory to make fake objects for testing
+"""
+from datetime import date
+import factory
+from factory.fuzzy import FuzzyInteger, FuzzyDate
+from service.models import Wishlist
+
+
+class WishlistFactory(factory.Factory):
+    """Creates fake Wishlists"""
+
+    # pylint: disable=too-few-public-methods
+    class Meta:
+        """Persistent class"""
+        model = Wishlist
+
+    wishlist_id = factory.Sequence(lambda n: n)
+    customer_id = FuzzyInteger(0, 255) # random customer id
+    date_joined = FuzzyDate(date(2008, 1, 1)) # random date from _ to today
+    

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -18,4 +18,3 @@ class WishlistFactory(factory.Factory):
     wishlist_id = factory.Sequence(lambda n: n)
     customer_id = FuzzyInteger(0, 255) # random customer id
     date_joined = FuzzyDate(date(2008, 1, 1)) # random date from _ to today
-    

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -17,4 +17,5 @@ class WishlistFactory(factory.Factory):
 
     wishlist_id = factory.Sequence(lambda n: n)
     customer_id = FuzzyInteger(0, 255) # random customer id
+    wishlist_name = factory.Faker("name") #random wishlist name
     created_date = FuzzyDate(date(2008, 1, 1)) # random date from _ to today

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -17,4 +17,4 @@ class WishlistFactory(factory.Factory):
 
     wishlist_id = factory.Sequence(lambda n: n)
     customer_id = FuzzyInteger(0, 255) # random customer id
-    date_joined = FuzzyDate(date(2008, 1, 1)) # random date from _ to today
+    created_date = FuzzyDate(date(2008, 1, 1)) # random date from _ to today

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,8 @@ import logging
 import unittest
 from service import app
 from service.models import Wishlist, DataValidationError, db
+from tests.factories import WishlistFactory
+
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/postgres"
@@ -45,6 +47,15 @@ class TestWishlist(unittest.TestCase):
     #  T E S T   C A S E S
     ######################################################################
 
-    def test_example_replace_this(self):
-        """ It should always be true """
-        self.assertTrue(True)
+    def test_create_a_wishlist(self):
+        """It should Create an Wishlist and assert that it exists"""
+        fake_wishlist = WishlistFactory()
+        # pylint: disable=unexpected-keyword-arg
+        wishlist = Wishlist(
+            customer_id=fake_wishlist.customer_id,
+            created_date=fake_wishlist.created_date,
+        )
+        self.assertIsNotNone(wishlist)
+        self.assertEqual(wishlist.wishlist_id, None)
+        self.assertEqual(wishlist.customer_id, fake_wishlist.customer_id)
+        self.assertEqual(wishlist.created_date, fake_wishlist.created_date)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -121,3 +121,13 @@ class TestWishlist(unittest.TestCase):
         wishlist.delete()
         wishlists = Wishlist.all()
         self.assertEqual(len(wishlists), 0)
+
+    def test_list_all_wishlists(self):
+        """It should List all wishlists in the database"""
+        wishlists = Wishlist.all()
+        self.assertEqual(wishlists, [])
+        for account in WishlistFactory.create_batch(5):
+            account.create()
+        # Assert that there are not 5 wishlists in the database
+        wishlists = Wishlist.all()
+        self.assertEqual(len(wishlists), 5)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -48,7 +48,7 @@ class TestWishlist(unittest.TestCase):
     ######################################################################
 
     def test_create_a_wishlist(self):
-        """It should Create an Wishlist and assert that it exists"""
+        """It should Create a Wishlist and assert that it exists"""
         fake_wishlist = WishlistFactory()
         # pylint: disable=unexpected-keyword-arg
         wishlist = Wishlist(
@@ -59,3 +59,14 @@ class TestWishlist(unittest.TestCase):
         self.assertEqual(wishlist.wishlist_id, None)
         self.assertEqual(wishlist.customer_id, fake_wishlist.customer_id)
         self.assertEqual(wishlist.created_date, fake_wishlist.created_date)
+
+    def test_add_a_wishlist(self):
+        """It should Create a Wishlist and add it to the database"""
+        wishlists = Wishlist.all()
+        self.assertEqual(wishlists, [])
+        wishlist = WishlistFactory()
+        wishlist.create()
+        # Assert that it was assigned an id and shows up in the database
+        self.assertIsNotNone(wishlist.wishlist_id)
+        wishlists = Wishlist.all()
+        self.assertEqual(len(wishlists), 1)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -77,6 +77,13 @@ class TestWishlist(unittest.TestCase):
         wishlists = Wishlist.all()
         self.assertEqual(len(wishlists), 1)
 
+        # Second addition
+        wishlist = WishlistFactory()
+        wishlist.create()
+        self.assertIsNotNone(wishlist.wishlist_id)
+        wishlists = Wishlist.all()
+        self.assertEqual(len(wishlists), 2)
+
     def test_read_wishlist(self):
         """It should Read a Wishlist"""
         wishlist = WishlistFactory()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -161,3 +161,18 @@ class TestWishlist(unittest.TestCase):
         """It should not Deserialize an wishlist with a TypeError"""
         wishlist = Wishlist()
         self.assertRaises(DataValidationError, wishlist.deserialize, [])
+
+    def test_repr_wishlist(self):
+        """It should represent wishlist as a string"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        given_id = wishlist.wishlist_id
+        repr_string=repr(wishlist)
+        expected_repr = f"<wishlist_id=[{given_id}]>"
+        self.assertEqual(repr_string, expected_repr)
+    
+    def test_id_is_none_wishlist(self):
+        """It should represent id as a none because we use wishlist_id"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        self.assertIsNone(wishlist.id)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -151,3 +151,13 @@ class TestWishlist(unittest.TestCase):
         self.assertEqual(new_wishlist.customer_id, wishlist.customer_id)
         self.assertEqual(new_wishlist.wishlist_name, wishlist.wishlist_name)
         self.assertEqual(new_wishlist.created_date, wishlist.created_date)
+
+    def test_deserialize_with_key_error(self):
+        """It should not Deserialize an wishlist with a KeyError"""
+        wishlist = Wishlist()
+        self.assertRaises(DataValidationError, wishlist.deserialize, {})
+
+    def test_deserialize_with_type_error(self):
+        """It should not Deserialize an wishlist with a TypeError"""
+        wishlist = Wishlist()
+        self.assertRaises(DataValidationError, wishlist.deserialize, [])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -39,6 +39,8 @@ class TestWishlist(unittest.TestCase):
 
     def setUp(self):
         """ This runs before each test """
+        db.session.query(Wishlist).delete()  # clean up the last tests
+        db.session.commit()
 
     def tearDown(self):
         """ This runs after each test """
@@ -102,3 +104,20 @@ class TestWishlist(unittest.TestCase):
         # Fetch it back again
         wishlist = Wishlist.find(wishlist.wishlist_id)
         self.assertEqual(wishlist.wishlist_name, "name is changed")
+
+    def test_delete_an_wishlist(self):
+        """It should Delete a wishlist from the database"""
+        wishlists = Wishlist.all()
+        self.assertEqual(wishlists, [])
+        wishlist = WishlistFactory()
+        wishlist.create()
+        # Assert that it was assigned an id and shows up in the database
+        self.assertIsNotNone(wishlist.wishlist_id)
+        last_id = wishlist.wishlist_id
+        wishlists = Wishlist.all()
+        self.assertEqual(len(wishlists), 1)
+        wishlist = wishlists[0]
+        self.assertEqual(wishlist.wishlist_id, last_id)
+        wishlist.delete()
+        wishlists = Wishlist.all()
+        self.assertEqual(len(wishlists), 0)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,6 +35,7 @@ class TestWishlist(unittest.TestCase):
         """ This runs once after the entire test suite """
         db.session.query(Wishlist).delete()  # clean up the last tests
         db.session.commit()
+        #db.drop_all() #Drops all tables if needed for updating schema
 
     def setUp(self):
         """ This runs before each test """
@@ -74,7 +75,7 @@ class TestWishlist(unittest.TestCase):
         self.assertEqual(len(wishlists), 1)
 
     def test_read_wishlist(self):
-        """It should Read an wishlist"""
+        """It should Read a wishlist"""
         wishlist = WishlistFactory()
         wishlist.create()
 
@@ -85,4 +86,19 @@ class TestWishlist(unittest.TestCase):
         self.assertEqual(found_wishlist.wishlist_name, wishlist.wishlist_name)
         self.assertEqual(found_wishlist.created_date, wishlist.created_date)
 
-    
+    def test_update_wishlist(self):
+        """It should Update a wishlist"""
+        wishlist = WishlistFactory(wishlist_name="change name")
+        wishlist.create()
+        # Assert that it was assigned an id and shows up in the database
+        self.assertIsNotNone(wishlist.wishlist_id)
+        self.assertEqual(wishlist.wishlist_name, "change name")
+
+        # Fetch it back
+        wishlist = Wishlist.find(wishlist.wishlist_id)
+        wishlist.wishlist_name = "name is changed"
+        wishlist.update()
+
+        # Fetch it back again
+        wishlist = Wishlist.find(wishlist.wishlist_id)
+        self.assertEqual(wishlist.wishlist_name, "name is changed")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,16 +14,17 @@ DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/postgres"
 )
 
+
 ######################################################################
 #  Wishlist   M O D E L   T E S T   C A S E S
 ######################################################################
 # pylint: disable=too-many-public-methods
 class TestWishlist(unittest.TestCase):
-    """ Test Cases for Wishlist Model """
+    """Test Cases for Wishlist Model"""
 
     @classmethod
     def setUpClass(cls):
-        """ This runs once before the entire test suite """
+        """This runs once before the entire test suite"""
         app.config["TESTING"] = True
         app.config["DEBUG"] = False
         app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
@@ -32,26 +33,26 @@ class TestWishlist(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        """ This runs once after the entire test suite """
+        """This runs once after the entire test suite"""
         db.session.query(Wishlist).delete()  # clean up the last tests
         db.session.commit()
-        #db.drop_all() #Drops all tables if needed for updating schema
+        # db.drop_all() #Drops all tables if needed for updating schema
 
     def setUp(self):
-        """ This runs before each test """
+        """This runs before each test"""
         db.session.query(Wishlist).delete()  # clean up the last tests
         db.session.commit()
 
     def tearDown(self):
-        """ This runs after each test """
+        """This runs after each test"""
         db.session.remove()
 
     ######################################################################
     #  T E S T   C A S E S
     ######################################################################
 
-    def test_create_a_wishlist(self):
-        """It should Create a Wishlist and assert that it exists"""
+    def test_define_a_wishlist(self):
+        """It should Define a Wishlist and assert that it is correct"""
         fake_wishlist = WishlistFactory()
         # pylint: disable=unexpected-keyword-arg
         wishlist = Wishlist(
@@ -65,7 +66,7 @@ class TestWishlist(unittest.TestCase):
         self.assertEqual(wishlist.wishlist_name, fake_wishlist.wishlist_name)
         self.assertEqual(wishlist.created_date, fake_wishlist.created_date)
 
-    def test_add_a_wishlist(self):
+    def test_create_a_wishlist(self):
         """It should Create a Wishlist and add it to the database"""
         wishlists = Wishlist.all()
         self.assertEqual(wishlists, [])
@@ -167,7 +168,7 @@ class TestWishlist(unittest.TestCase):
         wishlist = WishlistFactory()
         wishlist.create()
         given_id = wishlist.wishlist_id
-        repr_string=repr(wishlist)
+        repr_string = repr(wishlist)
         expected_repr = f"<wishlist_id=[{given_id}]>"
         self.assertEqual(repr_string, expected_repr)
 
@@ -183,4 +184,4 @@ class TestWishlist(unittest.TestCase):
         for wishlist in WishlistFactory.create_batch(5):
             wishlist.create()
             self.assertEqual(wishlist.wishlist_id, expected)
-            expected +=1
+            expected += 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -70,3 +70,16 @@ class TestWishlist(unittest.TestCase):
         self.assertIsNotNone(wishlist.wishlist_id)
         wishlists = Wishlist.all()
         self.assertEqual(len(wishlists), 1)
+
+    def test_read_wishlist(self):
+        """It should Read an wishlist"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+
+        # Read it back
+        found_wishlist = Wishlist.find(wishlist.wishlist_id)
+        self.assertEqual(found_wishlist.wishlist_id, wishlist.wishlist_id)
+        self.assertEqual(found_wishlist.customer_id, wishlist.customer_id)
+        self.assertEqual(found_wishlist.created_date, wishlist.created_date)
+
+    

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -170,9 +170,17 @@ class TestWishlist(unittest.TestCase):
         repr_string=repr(wishlist)
         expected_repr = f"<wishlist_id=[{given_id}]>"
         self.assertEqual(repr_string, expected_repr)
-    
-    def test_id_is_none_wishlist(self):
-        """It should represent id as a none because we use wishlist_id"""
+
+    def test_wishlist_id_is_increment(self):
+        """It should represent wishlist_id as incrementing"""
+        wishlists = Wishlist.all()
+        self.assertEqual(wishlists, [])
+
         wishlist = WishlistFactory()
         wishlist.create()
-        self.assertIsNone(wishlist.id)
+        expected = wishlist.wishlist_id + 1
+
+        for wishlist in WishlistFactory.create_batch(5):
+            wishlist.create()
+            self.assertEqual(wishlist.wishlist_id, expected)
+            expected +=1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,33 +1,45 @@
 """
-Test cases for YourResourceModel Model
+Test cases for Wishlist Model
 
 """
 import os
 import logging
 import unittest
-from service.models import YourResourceModel, DataValidationError, db
+from service import app
+from service.models import Wishlist, DataValidationError, db
 
+DATABASE_URI = os.getenv(
+    "DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/postgres"
+)
 
 ######################################################################
-#  YourResourceModel   M O D E L   T E S T   C A S E S
+#  Wishlist   M O D E L   T E S T   C A S E S
 ######################################################################
 # pylint: disable=too-many-public-methods
-class TestYourResourceModel(unittest.TestCase):
-    """ Test Cases for YourResourceModel Model """
+class TestWishlist(unittest.TestCase):
+    """ Test Cases for Wishlist Model """
 
     @classmethod
     def setUpClass(cls):
         """ This runs once before the entire test suite """
+        app.config["TESTING"] = True
+        app.config["DEBUG"] = False
+        app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
+        app.logger.setLevel(logging.CRITICAL)
+        Wishlist.init_db(app)
 
     @classmethod
     def tearDownClass(cls):
         """ This runs once after the entire test suite """
+        db.session.query(Wishlist).delete()  # clean up the last tests
+        db.session.commit()
 
     def setUp(self):
         """ This runs before each test """
 
     def tearDown(self):
         """ This runs after each test """
+        db.session.remove()
 
     ######################################################################
     #  T E S T   C A S E S

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -53,11 +53,13 @@ class TestWishlist(unittest.TestCase):
         # pylint: disable=unexpected-keyword-arg
         wishlist = Wishlist(
             customer_id=fake_wishlist.customer_id,
+            wishlist_name=fake_wishlist.wishlist_name,
             created_date=fake_wishlist.created_date,
         )
         self.assertIsNotNone(wishlist)
         self.assertEqual(wishlist.wishlist_id, None)
         self.assertEqual(wishlist.customer_id, fake_wishlist.customer_id)
+        self.assertEqual(wishlist.wishlist_name, fake_wishlist.wishlist_name)
         self.assertEqual(wishlist.created_date, fake_wishlist.created_date)
 
     def test_add_a_wishlist(self):
@@ -80,6 +82,7 @@ class TestWishlist(unittest.TestCase):
         found_wishlist = Wishlist.find(wishlist.wishlist_id)
         self.assertEqual(found_wishlist.wishlist_id, wishlist.wishlist_id)
         self.assertEqual(found_wishlist.customer_id, wishlist.customer_id)
+        self.assertEqual(found_wishlist.wishlist_name, wishlist.wishlist_name)
         self.assertEqual(found_wishlist.created_date, wishlist.created_date)
 
     

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -132,9 +132,30 @@ class TestWishlist(unittest.TestCase):
         self.assertEqual(len(wishlists), 1)
         wishlist = wishlists[0]
         self.assertEqual(wishlist.wishlist_id, last_id)
+        # Second Wishlist
+        wishlist_2 = WishlistFactory()
+        wishlist_2.create()
+        # Assert that it was assigned an id and shows up in the database
+        self.assertIsNotNone(wishlist_2.wishlist_id)
+        self.assertNotEqual(wishlist_2.wishlist_id, last_id)
+        last_id_2 = wishlist_2.wishlist_id
+        wishlists = Wishlist.all()
+        self.assertEqual(len(wishlists), 2)
+        # Delete first wishlist
         wishlist.delete()
         wishlists = Wishlist.all()
+        self.assertEqual(len(wishlists), 1)
+        wishlists_found = Wishlist.find(last_id)
+        self.assertIsNone(wishlists_found)
+        # Verify second wishlist exists
+        wishlists_found = Wishlist.find(last_id_2)
+        self.assertIsNotNone(wishlists_found)
+        # Delete second wishlist
+        wishlist_2.delete()
+        wishlists = Wishlist.all()
         self.assertEqual(len(wishlists), 0)
+        wishlists_found = Wishlist.find(last_id_2)
+        self.assertIsNone(wishlists_found)
 
     def test_list_all_wishlists(self):
         """It should List all Wishlists in the database"""
@@ -142,7 +163,7 @@ class TestWishlist(unittest.TestCase):
         self.assertEqual(wishlists, [])
         for wishlist in WishlistFactory.create_batch(5):
             wishlist.create()
-        # Assert that there are not 5 wishlists in the database
+        # Assert that there are now 5 wishlists in the database
         wishlists = Wishlist.all()
         self.assertEqual(len(wishlists), 5)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -77,7 +77,7 @@ class TestWishlist(unittest.TestCase):
         self.assertEqual(len(wishlists), 1)
 
     def test_read_wishlist(self):
-        """It should Read a wishlist"""
+        """It should Read a Wishlist"""
         wishlist = WishlistFactory()
         wishlist.create()
 
@@ -89,7 +89,7 @@ class TestWishlist(unittest.TestCase):
         self.assertEqual(found_wishlist.created_date, wishlist.created_date)
 
     def test_update_wishlist(self):
-        """It should Update a wishlist"""
+        """It should Update a Wishlist"""
         wishlist = WishlistFactory(wishlist_name="change name")
         wishlist.create()
         # Assert that it was assigned an id and shows up in the database
@@ -106,7 +106,7 @@ class TestWishlist(unittest.TestCase):
         self.assertEqual(wishlist.wishlist_name, "name is changed")
 
     def test_delete_an_wishlist(self):
-        """It should Delete a wishlist from the database"""
+        """It should Delete a Wishlist from the database"""
         wishlists = Wishlist.all()
         self.assertEqual(wishlists, [])
         wishlist = WishlistFactory()
@@ -123,11 +123,20 @@ class TestWishlist(unittest.TestCase):
         self.assertEqual(len(wishlists), 0)
 
     def test_list_all_wishlists(self):
-        """It should List all wishlists in the database"""
+        """It should List all Wishlists in the database"""
         wishlists = Wishlist.all()
         self.assertEqual(wishlists, [])
-        for account in WishlistFactory.create_batch(5):
-            account.create()
+        for wishlist in WishlistFactory.create_batch(5):
+            wishlist.create()
         # Assert that there are not 5 wishlists in the database
         wishlists = Wishlist.all()
         self.assertEqual(len(wishlists), 5)
+
+    def test_serialize_an_wishlist(self):
+        """It should Serialize an wishlist"""
+        wishlist = WishlistFactory()
+        serial_wishlist = wishlist.serialize()
+        self.assertEqual(serial_wishlist["wishlist_id"], wishlist.wishlist_id)
+        self.assertEqual(serial_wishlist["customer_id"], wishlist.customer_id)
+        self.assertEqual(serial_wishlist["wishlist_name"], wishlist.wishlist_name)
+        self.assertEqual(serial_wishlist["created_date"], str(wishlist.created_date))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -140,3 +140,14 @@ class TestWishlist(unittest.TestCase):
         self.assertEqual(serial_wishlist["customer_id"], wishlist.customer_id)
         self.assertEqual(serial_wishlist["wishlist_name"], wishlist.wishlist_name)
         self.assertEqual(serial_wishlist["created_date"], str(wishlist.created_date))
+
+    def test_deserialize_an_wishlist(self):
+        """It should Deserialize an wishlist"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        serial_wishlist = wishlist.serialize()
+        new_wishlist = Wishlist()
+        new_wishlist.deserialize(serial_wishlist)
+        self.assertEqual(new_wishlist.customer_id, wishlist.customer_id)
+        self.assertEqual(new_wishlist.wishlist_name, wishlist.wishlist_name)
+        self.assertEqual(new_wishlist.created_date, wishlist.created_date)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -91,20 +91,26 @@ class TestWishlist(unittest.TestCase):
 
     def test_update_wishlist(self):
         """It should Update a Wishlist"""
-        wishlist = WishlistFactory(wishlist_name="change name")
+
+        # Define names
+        old_name = "change name"
+        new_name = "different name"
+        self.assertNotEqual(old_name, new_name)
+
+        wishlist = WishlistFactory(wishlist_name=old_name)
         wishlist.create()
         # Assert that it was assigned an id and shows up in the database
         self.assertIsNotNone(wishlist.wishlist_id)
-        self.assertEqual(wishlist.wishlist_name, "change name")
+        self.assertEqual(wishlist.wishlist_name, old_name)
 
         # Fetch it back
         wishlist = Wishlist.find(wishlist.wishlist_id)
-        wishlist.wishlist_name = "name is changed"
+        wishlist.wishlist_name = new_name
         wishlist.update()
 
         # Fetch it back again
         wishlist = Wishlist.find(wishlist.wishlist_id)
-        self.assertEqual(wishlist.wishlist_name, "name is changed")
+        self.assertEqual(wishlist.wishlist_name, new_name)
 
     def test_delete_an_wishlist(self):
         """It should Delete a Wishlist from the database"""


### PR DESCRIPTION
#4 
Wrote CRUD+L support for basic wishlist model.
Wrote tests to cover CRUD+L and serialize/deserialize.
Wrote factory to generate basic wishlist model.

Green coverage for models.py is 98%
line 36 is not covered because it's a base model.

Need to check if "test_wishlist_id_is_increment" for correctness.

Note for adding "wishlist items" support, one may need to run "flask db-create". 