### PR TITLE
WISHLIST-19 - Define WishlistItem Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ tests/              - test cases package
 ├── test_models.py  - test suite for business models
 └── test_routes.py  - test suite for service routes
 ```
+## Running the App
+
+After opening vscode in our running container.  Execute the following command in the terminal.
+
+```flask run```
+
+## Running tests
+
+To run all tests in the project, use the following at the command line.
+
+```green```
 
 ## License
 

--- a/service/models.py
+++ b/service/models.py
@@ -159,12 +159,13 @@ class WishlistItem(db.Model, PersistentBase):
     product_id = db.Column(db.Integer)
     product_name = db.Column(db.String(255))
     product_price = db.Column(db.Numeric)
+    quantity = db.Column(db.Integer)
     created_date = db.Column(
         db.Date(), nullable=False, server_default=db.func.current_date()
     )
 
     def __repr__(self):
-        return f"WishlistItem(id={self.id}, wishlist_id={self.wishlist_id}, product_id={self.product_id}, product_name='{self.product_name}', product_price={self.product_price}, created_date='{self.created_date}')"
+        return f"WishlistItem(id={self.id}, wishlist_id={self.wishlist_id}, product_id={self.product_id}, product_name='{self.product_name}', product_price={self.product_price}, quantity={self.quantity}, created_date='{self.created_date}')"
 
     def serialize(self):
         return {
@@ -173,8 +174,26 @@ class WishlistItem(db.Model, PersistentBase):
             "product_id": self.product_id,
             "product_name": self.product_name,
             "product_price": self.product_price,
+            "quantity": self.quantity,
             "created_date": self.created_date,
         }
 
-    def deserialize(self, data):
-        pass
+    def deserialize(self, data: dict):
+        try:
+            self.id = data["id"]
+            self.wishlist_id = data["wishlist_id"]
+            self.product_id = data["product_id"]
+            self.product_name = data["product_name"]
+            self.product_price = data["product_price"]
+            self.quantity = data["quantity"]
+            self.created_date = data["created_date"]
+        except KeyError as error:
+            raise DataValidationError(
+                "Invalid Wishlist Item: missing " + error.args[0]
+            ) from error
+        except TypeError as error:
+            raise DataValidationError(
+                "Invalid Wishlist Item: body of request contained "
+                "bad or no data - " + error.args[0]
+            ) from error
+        return self

--- a/service/models.py
+++ b/service/models.py
@@ -33,7 +33,7 @@ class PersistentBase:
     """
 
     def __init__(self):
-        self.wishlist_id = None  # pylint: disable=invalid-name
+        self.id = None  # pylint: disable=invalid-name
 
     @abstractmethod
     def serialize(self) -> dict:
@@ -47,8 +47,8 @@ class PersistentBase:
         """
         Creates a Wishlist to the database
         """
-        logger.info("Creating %s", self.wishlist_id)
-        self.wishlist_id = None  # pylint: disable=invalid-name
+        logger.info("Creating %s", self.id)
+        self.id = None  # pylint: disable=invalid-name
         # id must be none to generate next primary key
         db.session.add(self)
         db.session.commit()
@@ -57,12 +57,12 @@ class PersistentBase:
         """
         Updates a Wishlist to the database
         """
-        logger.info("Saving %s", self.wishlist_id)
+        logger.info("Saving %s", self.id)
         db.session.commit()
 
     def delete(self):
         """Removes a Wishlist from the data store"""
-        logger.info("Deleting %s", self.wishlist_id)
+        logger.info("Deleting %s", self.id)
         db.session.delete(self)
         db.session.commit()
 
@@ -100,18 +100,18 @@ class Wishlist(db.Model, PersistentBase):
     app = None
 
     # Table Schema
-    wishlist_id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(db.Integer, primary_key=True)
     customer_id = db.Column(db.Integer)
     wishlist_name = db.Column(db.String(64))  # e.g., work, home, vacation, etc.
     created_date = db.Column(db.Date(), nullable=False, default=date.today())
 
     def __repr__(self):
-        return f"<wishlist_id=[{self.wishlist_id}]>"
+        return f"<wishlist_id=[{self.id}]>"
 
     def serialize(self):
         """Converts an Wishlist into a dictionary"""
         wishlist = {
-            "wishlist_id": self.wishlist_id,
+            "id": self.id,
             "customer_id": self.customer_id,
             "wishlist_name": self.wishlist_name,
             "created_date": self.created_date.isoformat(),
@@ -150,10 +150,10 @@ class WishlistItem(db.Model, PersistentBase):
     __tablename__ = "wishlist_items"
 
     # Table Schema
-    wishlist_item_id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(db.Integer, primary_key=True)
     wishlist_id = db.Column(
         db.Integer,
-        db.ForeignKey("wishlist.wishlist_id", ondelete="CASCADE"),
+        db.ForeignKey("wishlist.id", ondelete="CASCADE"),
         nullable=False,
     )
     product_id = db.Column(db.Integer)
@@ -162,23 +162,6 @@ class WishlistItem(db.Model, PersistentBase):
     created_date = db.Column(
         db.Date(), nullable=False, server_default=db.func.current_date()
     )
-
-    def __init__(
-        self,
-        id=None,
-        wishlist_id=None,
-        product_id=None,
-        product_name=None,
-        product_price=None,
-        created_date=None,
-    ):
-        super().__init__()
-        self.id = (id,)
-        self.wishlist_id = wishlist_id
-        self.product_id = product_id
-        self.product_name = product_name
-        self.product_price = product_price
-        self.created_date = created_date if created_date is not None else datetime.now()
 
     def __repr__(self):
         return f"WishlistItem(id={self.id}, wishlist_id={self.wishlist_id}, product_id={self.product_id}, product_name='{self.product_name}', product_price={self.product_price}, created_date='{self.created_date}')"
@@ -192,3 +175,6 @@ class WishlistItem(db.Model, PersistentBase):
             "product_price": self.product_price,
             "created_date": self.created_date,
         }
+
+    def deserialize(self, data):
+        pass

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -4,7 +4,7 @@ Test Factory to make fake objects for testing
 from datetime import date
 import factory
 from factory.fuzzy import FuzzyInteger, FuzzyDate
-from service.models import Wishlist
+from service.models import Wishlist, WishlistItem
 
 
 class WishlistFactory(factory.Factory):
@@ -13,9 +13,29 @@ class WishlistFactory(factory.Factory):
     # pylint: disable=too-few-public-methods
     class Meta:
         """Persistent class"""
+
         model = Wishlist
 
     wishlist_id = factory.Sequence(lambda n: n)
-    customer_id = FuzzyInteger(0, 255) # random customer id
-    wishlist_name = factory.Faker("name") #random wishlist name
-    created_date = FuzzyDate(date(2008, 1, 1)) # random date from _ to today
+    customer_id = FuzzyInteger(0, 255)  # random customer id
+    wishlist_name = factory.Faker("name")  # random wishlist name
+    created_date = FuzzyDate(date(2008, 1, 1))  # random date from _ to today
+
+
+class WishlistItemFactory(factory.Factory):
+    """Creates fake WishlistItems"""
+
+    # pylint: disable=too-few-public-methods
+    class Meta:
+        """Persistent class"""
+
+        model = WishlistItem
+
+    id = factory.Sequence(lambda n: n)
+    wishlist_id = FuzzyInteger(0, 1000)
+    product_id = FuzzyInteger(0, 255)
+    product_name = factory.Faker("name")
+    product_price = factory.Faker(
+        "pyfloat", left_digits=2, right_digits=2, positive=True
+    )
+    created_date = FuzzyDate(date(2008, 1, 1))

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -38,4 +38,5 @@ class WishlistItemFactory(factory.Factory):
     product_price = factory.Faker(
         "pyfloat", left_digits=2, right_digits=2, positive=True
     )
+    quantity = FuzzyInteger(0, 99)
     created_date = FuzzyDate(date(2008, 1, 1))

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,7 +16,7 @@ class WishlistFactory(factory.Factory):
 
         model = Wishlist
 
-    wishlist_id = factory.Sequence(lambda n: n)
+    id = factory.Sequence(lambda n: n)
     customer_id = FuzzyInteger(0, 255)  # random customer id
     wishlist_name = factory.Faker("name")  # random wishlist name
     created_date = FuzzyDate(date(2008, 1, 1))  # random date from _ to today

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -36,7 +36,6 @@ class TestWishlist(unittest.TestCase):
         """This runs once after the entire test suite"""
         db.session.query(Wishlist).delete()  # clean up the last tests
         db.session.commit()
-        # db.drop_all() #Drops all tables if needed for updating schema
 
     def setUp(self):
         """This runs before each test"""
@@ -221,8 +220,46 @@ class TestWishlist(unittest.TestCase):
             expected += 1
 
 
+#####################
+# WishistItem Tests
+#####################
 class TestWishlistItem(unittest.TestCase):
     """Test cases for WishlistItem Model"""
+
+    serialized = {}
+
+    @classmethod
+    def tearDownClass(cls):
+        """This runs once after the entire test suite"""
+        db.session.query(WishlistItem).delete()
+        db.session.commit()
+
+    def setUp(self):
+        """This runs before each test"""
+        db.session.query(WishlistItem).delete()
+        db.session.commit()
+
+        self.serialized = {
+            "id": 1,
+            "wishlist_id": 2,
+            "product_id": 3,
+            "product_name": "DevOps for Dummies",
+            "product_price": 29.99,
+            "quantity": 2,
+            "created_date": datetime.strptime(
+                "2023-10-12 00:00:00", "%Y-%m-%d %H:%M:%S"
+            ),
+        }
+
+    def tearDown(self):
+        """This runs after each test"""
+        db.session.remove()
+
+    def test_wishlist_item_init_clears_id(self):
+        """It should ensure id is set to None upon initialization"""
+        item = WishlistItem()
+        item.__init__()
+        self.assertIsNone(item.id)
 
     def test_wishlist_item_no_arg_initializer(self):
         """It should create an instance using the no arg initializer"""
@@ -256,12 +293,14 @@ class TestWishlistItem(unittest.TestCase):
         self.assertEqual(item.product_price, values["product_price"])
         self.assertEqual(item.created_date, values["created_date"])
 
-    def test_repr_method(self):
+    def test_wishlist_item_repr_method(self):
+        """It should give a correct response when calling __repr__"""
         item = WishlistItemFactory()
-        expected = f"WishlistItem(id={item.id}, wishlist_id={item.wishlist_id}, product_id={item.product_id}, product_name='{item.product_name}', product_price={item.product_price}, created_date='{item.created_date}')"
+        expected = f"WishlistItem(id={item.id}, wishlist_id={item.wishlist_id}, product_id={item.product_id}, product_name='{item.product_name}', product_price={item.product_price}, quantity={item.quantity}, created_date='{item.created_date}')"
         self.assertEqual(repr(item), expected)
 
-    def test_serialize(self):
+    def test_wishlist_item_serialize(self):
+        """It should serialize a wishlist item"""
         item = WishlistItemFactory()
         serialized = item.serialize()
         self.assertEqual(item.wishlist_id, serialized["wishlist_id"])
@@ -269,3 +308,120 @@ class TestWishlistItem(unittest.TestCase):
         self.assertEqual(item.product_name, serialized["product_name"])
         self.assertEqual(item.product_price, serialized["product_price"])
         self.assertEqual(item.created_date, serialized["created_date"])
+
+    def test_wishlist_item_deserialize(self):
+        """It should deserialize a wishlist"""
+
+        item = WishlistItem()
+        item.deserialize(self.serialized)
+        self.assertEqual(item.id, self.serialized["id"])
+        self.assertEqual(item.wishlist_id, self.serialized["wishlist_id"])
+        self.assertEqual(item.product_id, self.serialized["product_id"])
+        self.assertEqual(item.product_name, self.serialized["product_name"])
+        self.assertEqual(item.product_price, self.serialized["product_price"])
+        self.assertEqual(item.quantity, self.serialized["quantity"])
+        self.assertEqual(item.created_date, self.serialized["created_date"])
+
+    def test_wishlist_item_deserialize_with_invalid_data_type(self):
+        """It should raise a DataValidationError when serializing from incorrect type"""
+
+        item = WishlistItem()
+        self.assertRaises(
+            DataValidationError,
+            item.deserialize,
+            "You can't deserialize me. I'm a mighty STRING!!!",
+        )
+
+    def test_wishlist_item_deserialize_with_invalid_input(self):
+        """It should throw a DataValidationError when a serialized object is missing a key"""
+
+        del self.serialized["product_name"]
+        item = WishlistItem()
+        self.assertRaises(DataValidationError, item.deserialize, self.serialized)
+
+    # don't love this approach.  This is why it feels slightly wrong to me to unit test with DB
+    # I have to rely on the wishlist Model functioning for this test to pass otherwise the Foreign Key
+    # constraint will fail when trying to save an arbitrary wishlist_id
+    def test_wishlist_item_create(self):
+        """It creates (inserts) a WishListItem"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        item = WishlistItemFactory()
+        item.wishlist_id = wishlist.id
+        # ensure id is None before saving (which will auto increment/assign the id)
+        item.id = None
+        item.create()
+        self.assertIsNotNone(item.id)
+
+    def test_wishlist_item_find(self):
+        """It reads (finds) a WishListItem"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        item = WishlistItemFactory()
+        item.wishlist_id = wishlist.id
+        item.create()
+        item_id = item.id
+
+        print(f"Item: {item.__repr__}")
+
+        found_item = WishlistItem.find(item_id)
+
+        self.assertIsNotNone(found_item)
+
+        print(f"Found Item: {found_item.__repr__}")
+
+        self.assertEqual(item, found_item)
+
+    def test_wishlist_item_update(self):
+        """It should update a previously saved Wishlist_Item"""
+
+        wishlist = WishlistFactory()
+        wishlist.create()
+        item = WishlistItemFactory()
+        # set foreign key to some pre-existing wishlist_id
+        item.wishlist_id = wishlist.id
+        item.id = None
+        item.create()
+
+        self.assertIsNotNone(item.id)
+
+        # now update (quantity is really the only thing which makes sense to update)
+        incremented_quantity = item.quantity + 1
+        item.quantity = incremented_quantity
+        item.update()
+
+        found_item = WishlistItem.find(item.id)
+        self.assertEqual(incremented_quantity, found_item.quantity)
+
+    def test_wishlist_delete(self):
+        "It should successfully delete a WishlistItem"
+
+        wishlist = WishlistFactory()
+        wishlist.create()
+        item = WishlistItemFactory()
+        # set foreign key to some pre-existing wishlist_id
+        item.wishlist_id = wishlist.id
+        item.create()
+
+        found_item = WishlistItem.find(item.id)
+        found_item_id = found_item.id
+        self.assertIsNotNone(found_item_id)
+
+        WishlistItem.delete(found_item)
+
+        ghost_item = WishlistItem.find(found_item_id)
+
+        self.assertIsNone(ghost_item)
+
+    def test_list_all_accounts(self):
+        """It should list all wishlist_items in the database"""
+        items = WishlistItem.all()
+        self.assertEqual(items, [])
+        wishlist = WishlistFactory()
+        wishlist.create()
+        for item in WishlistItemFactory.create_batch(5):
+            item.wishlist_id = wishlist.id
+            item.create()
+        # Assert that there are now 5 wishlist_items in the database
+        accounts = WishlistItem.all()
+        self.assertEqual(len(accounts), 5)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,9 +5,10 @@ Test cases for Wishlist Model
 import os
 import logging
 import unittest
+from datetime import datetime
 from service import app
-from service.models import Wishlist, DataValidationError, db
-from tests.factories import WishlistFactory
+from service.models import Wishlist, WishlistItem, DataValidationError, db
+from tests.factories import WishlistFactory, WishlistItemFactory
 
 
 DATABASE_URI = os.getenv(
@@ -219,3 +220,40 @@ class TestWishlist(unittest.TestCase):
             wishlist.create()
             self.assertEqual(wishlist.wishlist_id, expected)
             expected += 1
+
+
+class TestWishlistItem(unittest.TestCase):
+    """Test cases for WishlistItem Model"""
+
+    def test_wishlist_item_no_arg_initializer(self):
+        """It should create an instance using the no arg initializer"""
+        item = WishlistItem()
+        self.assertIsNotNone(item)
+        # self.assertIsNotNone(item.created_date)
+
+    def test_wishlist_item_initializer_with_args(self):
+        """It should create an instance using the constructor with arguments"""
+        now = datetime.now()
+        item = WishlistItem(1, 2, 3, "", 42.0, now)
+        self.assertEqual(item.id, 1)
+        self.assertEqual(item.wishlist_id, 2)
+        self.assertEqual(item.product_id, 3)
+        self.assertEqual(item.product_name, "")
+        self.assertEqual(item.product_price, 42.0)
+        self.assertEqual(item.created_date, now)
+
+    def test_repr_method(self):
+        item = WishlistItem(
+            1, 2, "Catcher in the Rye", 42.0, datetime(year=2023, month=10, day=15)
+        )
+        expected = "WishlistItem(id=1, wishlist_id=2, product_id=3, product_name='Catcher in the Rye', product_price=42.0, created_date='2023-10-15 00:00:00')"
+        self.assertEqual(repr(item), expected)
+
+    def test_serialize(self):
+        item = WishlistItemFactory()
+        serialized = item.serialize()
+        self.assertEqual(item.wishlist_id, serialized.wishlist_id)
+        self.assertEqual(item.product_id, serialized.product_id)
+        self.assertEqual(item.product_name, serialized.product_name)
+        self.assertEqual(item.product_price, serialized.product_price)
+        self.assertEqual(item.created_date, serialized.created_date)


### PR DESCRIPTION
Big refactoring to change the wishlist.wishlist_id field to wishlist.id.

99% test coverage for models.py.

More sad-path test cases could be added, but hopefully this will be enough to move on with other API functionality.