### PR TITLE
Read wishlist

### DIFF
--- a/service/common/error_handlers.py
+++ b/service/common/error_handlers.py
@@ -71,19 +71,19 @@ def method_not_supported(error):
     )
 
 
-@app.errorhandler(status.HTTP_409_CONFLICT)
-def resource_conflict(error):
-    """Handles resource conflicts with HTTP_409_CONFLICT"""
-    message = str(error)
-    app.logger.warning(message)
-    return (
-        jsonify(
-            status=status.HTTP_409_CONFLICT,
-            error="Conflict",
-            message=message,
-        ),
-        status.HTTP_409_CONFLICT,
-    )
+# @app.errorhandler(status.HTTP_409_CONFLICT)
+# def resource_conflict(error):
+#     """Handles resource conflicts with HTTP_409_CONFLICT"""
+#     message = str(error)
+#     app.logger.warning(message)
+#     return (
+#         jsonify(
+#             status=status.HTTP_409_CONFLICT,
+#             error="Conflict",
+#             message=message,
+#         ),
+#         status.HTTP_409_CONFLICT,
+#     )
 
 
 @app.errorhandler(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)

--- a/service/routes.py
+++ b/service/routes.py
@@ -59,6 +59,27 @@ def create_wishlists():
         {"Location": f"/wishlists/{wishlist.id}"},
     )
 
+@app.route("/wishlists/<int:id>", methods=["GET"])
+def read_wishlists(id):
+    """
+    Reads an Existing Wishlist
+    This endpoint will read a Wishlist based on the given id
+    """
+    app.logger.info(f"Request to read Wishlist: {id}")
+
+    # Validate content is json
+    check_content_type("application/json")
+
+    # Check if wishlist exists
+    wishlist = Wishlist.find(id)
+    if not wishlist:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Wishlist with id '{id}' could not be found."
+        )
+    return make_response(jsonify(wishlist.serialize()), status.HTTP_200_OK)
+   
+
 
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S

--- a/service/routes.py
+++ b/service/routes.py
@@ -59,27 +59,26 @@ def create_wishlists():
         {"Location": f"/wishlists/{wishlist.id}"},
     )
 
-@app.route("/wishlists/<int:id>", methods=["GET"])
-def read_wishlists(id):
+
+@app.route("/wishlists/<int:wishlist_id>", methods=["GET"])
+def read_wishlists(wishlist_id):
     """
     Reads an Existing Wishlist
     This endpoint will read a Wishlist based on the given id
     """
-    app.logger.info(f"Request to read Wishlist: {id}")
+    app.logger.info("Request to read Wishlist: %d", wishlist_id)
 
     # Validate content is json
     check_content_type("application/json")
 
     # Check if wishlist exists
-    wishlist = Wishlist.find(id)
+    wishlist = Wishlist.find(wishlist_id)
     if not wishlist:
         abort(
             status.HTTP_404_NOT_FOUND,
-            f"Wishlist with id '{id}' could not be found."
+            f"Wishlist with id '{wishlist_id}' could not be found."
         )
     return make_response(jsonify(wishlist.serialize()), status.HTTP_200_OK)
-   
-
 
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -52,11 +52,9 @@ class TestWishlistServer(TestCase):
         """This runs after each test"""
         db.session.remove()
 
-    
     ######################################################################
     #  H E L P E R   M E T H O D S
     ######################################################################
-
     def _create_wishlists(self, count):
         """Wishlist method to create wishlists in bulk"""
         wishlists = []
@@ -73,11 +71,9 @@ class TestWishlistServer(TestCase):
             wishlists.append(wishlist)
         return wishlists
 
-
     ######################################################################
     #  W I S H L I S T   T E S T   C A S E S   H E R E
     ######################################################################
-
     def test_index(self):
         """It should call the home page"""
         resp = self.client.get("/")
@@ -107,7 +103,7 @@ class TestWishlistServer(TestCase):
             str(wishlist.created_date),
             "Created Date does not match",
         )
-    
+
     def test_bad_request(self):
         """It should not Create when sending the wrong data"""
         resp = self.client.post(BASE_URL, json={"wishlist_name": "my wishlist"})
@@ -116,17 +112,17 @@ class TestWishlistServer(TestCase):
     def test_get_wishlist(self):
         """It checks if the GET Method to read a wishlist works"""
         wishlist = self._create_wishlists(1)[0]
-        id = wishlist.id
+        wishlist_id = wishlist.id
         customer_id = wishlist.customer_id
         wishlist_name = wishlist.wishlist_name
-        created_date = str(wishlist.created_date) # convert datetime object to string since resp will be in json
+        created_date = str(wishlist.created_date)  # convert datetime object to string since resp will be in json
         resp = self.client.get(
-            f'{BASE_URL}/{id}',
+            f'{BASE_URL}/{wishlist_id}',
             content_type="application/json"
         )
         data = resp.get_json()
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(data['id'], id)
+        self.assertEqual(data['id'], wishlist_id)
         self.assertEqual(data['customer_id'], customer_id)
         self.assertEqual(data['wishlist_name'], wishlist_name)
         self.assertEqual(data['created_date'], str(created_date))

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -52,6 +52,28 @@ class TestWishlistServer(TestCase):
         """This runs after each test"""
         db.session.remove()
 
+    
+    ######################################################################
+    #  H E L P E R   M E T H O D S
+    ######################################################################
+
+    def _create_accounts(self, count):
+        """Wishlist method to create wishlists in bulk"""
+        wishlists = []
+        for _ in range(count):
+            wishlist = WishlistFactory()
+            resp = self.client.post(BASE_URL, json=wishlist.serialize())
+            self.assertEqual(
+                resp.status_code,
+                status.HTTP_201_CREATED,
+                "Could not create test Wishlist",
+            )
+            new_account = resp.get_json()
+            wishlist.id = new_account["id"]
+            wishlists.append(wishlist)
+        return wishlists
+
+
     ######################################################################
     #  W I S H L I S T   T E S T   C A S E S   H E R E
     ######################################################################
@@ -85,6 +107,37 @@ class TestWishlistServer(TestCase):
             str(wishlist.created_date),
             "Created Date does not match",
         )
+    
+    def test_bad_request(self):
+        """It should not Create when sending the wrong data"""
+        resp = self.client.post(BASE_URL, json={"wishlist_name": "my wishlist"})
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_wishlist(self):
+        """It checks if the GET Method to read a wishlist works"""
+        wishlist = self._create_accounts(1)[0]
+        id = wishlist.id
+        customer_id = wishlist.customer_id
+        wishlist_name = wishlist.wishlist_name
+        created_date = str(wishlist.created_date) # convert datetime object to string since resp will be in json
+        resp = self.client.get(
+            f'{BASE_URL}/{id}',
+            content_type="application/json"
+        )
+        data = resp.get_json()
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(data['id'], id)
+        self.assertEqual(data['customer_id'], customer_id)
+        self.assertEqual(data['wishlist_name'], wishlist_name)
+        self.assertEqual(data['created_date'], str(created_date))
+
+    def test_get_wishlist_not_found(self):
+        """It should not Read an Wishlist that is not found"""
+        resp = self.client.get(
+            f"{BASE_URL}/0",
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_unsupported_media_type(self):
         """It should not Create when sending wrong media type"""
@@ -94,3 +147,8 @@ class TestWishlistServer(TestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
         self.assertIsNotNone(resp.get_json())
+
+    def test_method_not_allowed(self):
+        """It should not allow an illegal method call"""
+        resp = self.client.put(BASE_URL, json={"not": "today"})
+        self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -57,7 +57,7 @@ class TestWishlistServer(TestCase):
     #  H E L P E R   M E T H O D S
     ######################################################################
 
-    def _create_accounts(self, count):
+    def _create_wishlists(self, count):
         """Wishlist method to create wishlists in bulk"""
         wishlists = []
         for _ in range(count):
@@ -115,7 +115,7 @@ class TestWishlistServer(TestCase):
 
     def test_get_wishlist(self):
         """It checks if the GET Method to read a wishlist works"""
-        wishlist = self._create_accounts(1)[0]
+        wishlist = self._create_wishlists(1)[0]
         id = wishlist.id
         customer_id = wishlist.customer_id
         wishlist_name = wishlist.wishlist_name


### PR DESCRIPTION
#17 
1. Added the `read_wishlists` GET endpoint.
2. Added happy and sad test paths for `read_wishlists`.
3. Added `test_bad_request` test to maximize coverage.
4. Added `test_method_not_allowed` test to maximize coverage.
5. Added `_create_wishlists` to create dummy wishlists (to read from , while testing `test_get_wishlist`).
6. Commented `resource_conflict` from `/service/common/error_handlers.py` since we may not use it (as per Prof on Slack).
7. `internal_server_error` still to be implemented - not covered.
8. Code Coverage: 97%