### PR TITLE
Bug fix create dup item

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -189,7 +189,6 @@ class WishlistItem(db.Model, PersistentBase):
 
     def deserialize(self, data: dict):
         try:
-            self.id = data["id"]
             self.wishlist_id = data["wishlist_id"]
             self.product_id = data["product_id"]
             self.product_name = data["product_name"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -353,7 +353,6 @@ class TestWishlistItem(unittest.TestCase):
 
         item = WishlistItem()
         item.deserialize(self.serialized)
-        self.assertEqual(item.id, self.serialized["id"])
         self.assertEqual(item.wishlist_id, self.serialized["wishlist_id"])
         self.assertEqual(item.product_id, self.serialized["product_id"])
         self.assertEqual(item.product_name, self.serialized["product_name"])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -402,32 +402,6 @@ class TestWishlistItem(unittest.TestCase):
         self.assertEqual(len(new_wishlist.items), 2)
         self.assertEqual(new_wishlist.items[1].id, item2.id)
 
-    def test_add_duplicate_id_input_wishlist_item(self):
-        """It should Create a wishlist with 2 items and add it to the database"""
-        wishlists = Wishlist.all()
-        self.assertEqual(wishlists, [])
-        wishlist = WishlistFactory()
-        item = WishlistItemFactory(wishlist=wishlist)
-        id_from_factory = item.id  # Keep track of input
-        wishlist.items.append(item)
-        wishlist.create()
-        # Assert that it was assigned an id and shows up in the database
-        self.assertIsNotNone(wishlist.id)
-        wishlists = Wishlist.all()
-        self.assertEqual(len(wishlists), 1)
-
-        new_wishlist = Wishlist.find(wishlist.id)
-        self.assertEqual(new_wishlist.items[0].id, item.id)
-
-        item2 = WishlistItemFactory(wishlist=wishlist)
-        item2.id = id_from_factory  # Replicate issue #56 behavior
-        wishlist.items.append(item2)
-        wishlist.update()
-
-        new_wishlist = Wishlist.find(wishlist.id)
-        self.assertEqual(len(new_wishlist.items), 2)
-        self.assertEqual(new_wishlist.items[1].id, item2.id)
-
     def test_update_wishlist_item(self):
         """It should Update a wishlist's item"""
         wishlists = Wishlist.all()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -402,6 +402,32 @@ class TestWishlistItem(unittest.TestCase):
         self.assertEqual(len(new_wishlist.items), 2)
         self.assertEqual(new_wishlist.items[1].id, item2.id)
 
+    def test_add_duplicate_id_input_wishlist_item(self):
+        """It should Create a wishlist with 2 items and add it to the database"""
+        wishlists = Wishlist.all()
+        self.assertEqual(wishlists, [])
+        wishlist = WishlistFactory()
+        item = WishlistItemFactory(wishlist=wishlist)
+        id_from_factory = item.id  # Keep track of input
+        wishlist.items.append(item)
+        wishlist.create()
+        # Assert that it was assigned an id and shows up in the database
+        self.assertIsNotNone(wishlist.id)
+        wishlists = Wishlist.all()
+        self.assertEqual(len(wishlists), 1)
+
+        new_wishlist = Wishlist.find(wishlist.id)
+        self.assertEqual(new_wishlist.items[0].id, item.id)
+
+        item2 = WishlistItemFactory(wishlist=wishlist)
+        item2.id = id_from_factory  # Replicate issue #56 behavior
+        wishlist.items.append(item2)
+        wishlist.update()
+
+        new_wishlist = Wishlist.find(wishlist.id)
+        self.assertEqual(len(new_wishlist.items), 2)
+        self.assertEqual(new_wishlist.items[1].id, item2.id)
+
     def test_update_wishlist_item(self):
         """It should Update a wishlist's item"""
         wishlists = Wishlist.all()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -283,6 +283,31 @@ class TestWishlistServer(TestCase):
             "Created Date does not match",
         )
 
+    def test_create_duplicate_wishlist_item(self):
+        """It should create 2 new Wishlist Items and associate it with a specific Wishlist"""
+        # Create a Wishlist to associate the item with
+        wishlist = self._create_wishlists(1)[0]
+
+        # Confirm that wishlist.id is not None
+        self.assertIsNotNone(wishlist.id)
+
+        # Create a Wishlist Item
+        wishlist_item = WishlistItemFactory()
+        resp = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items",
+            json=wishlist_item.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Create a second identical Wishlist Item
+        resp = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items",
+            json=wishlist_item.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
     def test_create_wishlist_item_bad_request(self):
         """It should not create a Wishlist Item when sending the wrong data"""
         wishlist = WishlistFactory()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -240,16 +240,16 @@ class TestWishlistServer(TestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 
+        # Check the data is correct (response from db)
+        data = resp.get_json()
+
         # Ensure that the Location header is set and matches the expected URL
-        expected_location = f"{BASE_URL}/{wishlist.id}/items/{wishlist_item.id}"
+        expected_location = f"{BASE_URL}/{wishlist.id}/items/{data['id']}"
         self.assertEqual(resp.headers["Location"], expected_location)
 
         # Make sure location header is set (part of RESTful api definition)
         location = resp.headers.get("Location", None)
         self.assertIsNotNone(location)
-
-        # Check the data is correct (response from db)
-        data = resp.get_json()
 
         self.assertEqual(
             data["wishlist_id"],


### PR DESCRIPTION
Hi team, this is the fix to address a bug as described in the issue.
What I did:

- Added test case for our endpoints to replicate the behavior, can be run using green
- refactored the item model to not deserialize "id" because we do not want user-defined id's in our database
- refactored some tests to reflect that change

Green: pass all test 320 | 7 | 98%
Make Lint: 10.00/10