### PR TITLE
WISHLIST-58 - Query Wishlists by Customer ID

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -141,6 +141,20 @@ class Wishlist(db.Model, PersistentBase):
             ) from error
         return self
 
+    @classmethod
+    def find_by_customer_id(cls, customer_id: int) -> list:
+        """Returns all wishlists for a given customer id
+
+        :param customer_id: customer id of customer who owns the list
+        :type customer_id: int
+
+        :return: a collection of wishlists (or empty list)
+        :rtype: list
+
+        """
+        logger.info(f"Querying wishlists for customer id: [{customer_id}]")
+        return cls.query.filter(cls.customer_id == customer_id).all()
+
 
 ######################################################################
 # WISHLIST ITEM MODEL

--- a/service/models.py
+++ b/service/models.py
@@ -152,7 +152,7 @@ class Wishlist(db.Model, PersistentBase):
         :rtype: list
 
         """
-        logger.info(f"Querying wishlists for customer id: [{customer_id}]")
+        logger.info("Querying wishlists for customer id: [%s]", customer_id)
         return cls.query.filter(cls.customer_id == customer_id).all()
 
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -35,8 +35,17 @@ def index():
 @app.route("/wishlists", methods=["GET"])
 def list_wishlists():
     """Returns all of the Wishlists"""
-    app.logger.info("Request for Wishlist list")
-    wishlists = Wishlist.all()
+    app.logger.info("Request for Wishlist lists")
+
+    customer_id = request.args.get("customer-id")
+
+    wishlists = []
+
+    if customer_id is not None:
+        wishlists = Wishlist.find_by_customer_id(customer_id)
+    else:
+        wishlists = Wishlist.all()
+
     # Return as an array of dictionaries
     results = [wishlist.serialize() for wishlist in wishlists]
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -30,6 +30,20 @@ def index():
 
 
 ######################################################################
+# LIST ALL WISHLISTs
+######################################################################
+@app.route("/wishlists", methods=["GET"])
+def list_wishlists():
+    """Returns all of the Wishlists"""
+    app.logger.info("Request for Wishlist list")
+    wishlists = Wishlist.all()
+    # Return as an array of dictionaries
+    results = [wishlist.serialize() for wishlist in wishlists]
+
+    return make_response(jsonify(results), status.HTTP_200_OK)
+
+
+######################################################################
 # CREATE A NEW WISHLIST
 ######################################################################
 @app.route("/wishlists", methods=["POST"])
@@ -108,20 +122,6 @@ def update_wishlists_by_name(wishlist_id):
     wishlist.update()
 
     return make_response(jsonify(wishlist.serialize()), status.HTTP_200_OK)
-
-
-######################################################################
-# LIST ALL WISHLISTs
-######################################################################
-@app.route("/wishlists", methods=["GET"])
-def list_wishlists():
-    """Returns all of the Wishlists"""
-    app.logger.info("Request for Wishlist list")
-    wishlists = Wishlist.all()
-    # Return as an array of dictionaries
-    results = [wishlist.serialize() for wishlist in wishlists]
-
-    return make_response(jsonify(results), status.HTTP_200_OK)
 
 
 ######################################################################

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -198,6 +198,33 @@ class TestWishlist(unittest.TestCase):
         wishlists = Wishlist.all()
         self.assertEqual(len(wishlists), 5)
 
+    def test_wishlist_find_by_customer_id(self):
+        """It should return all the wishlists for a given customer id"""
+        lists = WishlistFactory.create_batch(3)
+
+        lists[0].customer_id = 1111
+        lists[1].customer_id = 2222
+        lists[2].customer_id = 2222
+
+        # insert lists into db
+        for wishlist in lists:
+            wishlist.create()
+
+        # fetch all from db
+        db_lists = Wishlist.all()
+        # make sure the inserts were successful
+        self.assertEqual(len(lists), len(db_lists))
+
+        customer_lists = Wishlist.find_by_customer_id(2222)
+        self.assertEqual(len(customer_lists), 2)
+
+    def test_wishlist_find_by_customer_id_for_non_existent_customer_id(self):
+        """It should return an empty list for non-existent customer id"""
+
+        results = Wishlist.find_by_customer_id(-1)
+
+        self.assertEqual(results, [])
+
     def test_serialize_an_wishlist(self):
         """It should Serialize an wishlist"""
         wishlist = WishlistFactory()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -49,6 +49,15 @@ class TestWishlist(unittest.TestCase):
     #  T E S T   C A S E S
     ######################################################################
 
+    # I still see models.py line 36 as missing from coverage
+    def test_persistent_base_init(self):
+        """PersistentBase class __init__ method sets id to None"""
+        wishlist = Wishlist()
+        self.assertIsNone(wishlist.id)
+
+        item = WishlistItem()
+        self.assertIsNone(item.id)
+
     def test_define_a_wishlist(self):
         """It should Define a Wishlist and assert that it is correct"""
         fake_wishlist = WishlistFactory()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -214,6 +214,14 @@ class TestWishlistServer(TestCase):
         # ensure we receive the two lists associated with customer 2222
         self.assertEqual(len(fetched_lists), 2)
 
+    def test_filter_wishlists_by_non_existent_customer_id(self):
+        url = f"{BASE_URL}?customer-id=-1"
+        resp = self.client.get(url)
+        fetched_lists = resp.get_json()
+
+        # ensure we receive the two lists associated with customer 2222
+        self.assertEqual(fetched_lists, [])
+
     def test_update_wishlist(self):
         """It should Update an existing Wishlist"""
         # create an Wishlist to update

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -215,6 +215,7 @@ class TestWishlistServer(TestCase):
         self.assertEqual(len(fetched_lists), 2)
 
     def test_filter_wishlists_by_non_existent_customer_id(self):
+        """It should return an empty list for non-existent customer id"""
         url = f"{BASE_URL}?customer-id=-1"
         resp = self.client.get(url)
         fetched_lists = resp.get_json()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -190,6 +190,30 @@ class TestWishlistServer(TestCase):
         self.assertEqual(len(data), 5)
         self.assertEqual(data, wishlist_array)
 
+    def test_filter_wishlists_by_customer_id(self):
+        """It should return wishlists for a given customer"""
+        lists = WishlistFactory.create_batch(3)
+
+        lists[0].customer_id = 1111
+        lists[1].customer_id = 2222
+        lists[2].customer_id = 2222
+
+        # insert lists into db
+        for wishlist in lists:
+            wishlist.create()
+
+        # fetch all from db
+        db_lists = Wishlist.all()
+        # make sure the inserts were successful
+        self.assertEqual(len(lists), len(db_lists))
+
+        url = f"{BASE_URL}?customer-id=2222"
+        resp = self.client.get(url)
+        fetched_lists = resp.get_json()
+
+        # ensure we receive the two lists associated with customer 2222
+        self.assertEqual(len(fetched_lists), 2)
+
     def test_update_wishlist(self):
         """It should Update an existing Wishlist"""
         # create an Wishlist to update

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -136,9 +136,7 @@ class TestWishlistServer(TestCase):
         created_date = str(
             wishlist.created_date
         )  # convert datetime object to string since resp will be in json
-        resp = self.client.get(
-            f"{BASE_URL}/{wishlist_id}"
-        )
+        resp = self.client.get(f"{BASE_URL}/{wishlist_id}")
         data = resp.get_json()
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(data["id"], wishlist_id)
@@ -228,6 +226,8 @@ class TestWishlistServer(TestCase):
 
         # ensure we receive the two lists associated with customer 2222
         self.assertEqual(len(fetched_lists), 2)
+
+        self.assertEqual(resp.status_code, 200)
 
     def test_filter_wishlists_by_non_existent_customer_id(self):
         """It should return an empty list for non-existent customer id"""
@@ -460,9 +460,7 @@ class TestWishlistServer(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
 
         # retrieve it back and make sure wishlist item is not there
-        resp = self.client.get(
-            f"{BASE_URL}/{wishlist.id}/addresses/{item_id}"
-        )
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/addresses/{item_id}")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_sad_path_delete_wishlist_item(self):
@@ -515,9 +513,7 @@ class TestWishlistServer(TestCase):
         logging.debug(data)
         item_id = data["id"]
 
-        resp = self.client.get(
-            f"{BASE_URL}/{wishlist.id}/items/{item_id}"
-        )
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items/{item_id}")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
         data = resp.get_json()
@@ -542,9 +538,7 @@ class TestWishlistServer(TestCase):
         item = WishlistItemFactory()
         item.wishlist_id = wishlist.id
 
-        resp = self.client.get(
-            f"{BASE_URL}/{wishlist.id}/items/{item.id}"
-        )
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items/{item.id}")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_update_wishlist_item(self):


### PR DESCRIPTION
This PR updates the Wishlist model to add a new ```find_by_customer_id``` method and adds support for a customer-id param on the ```GET /wishlists?customer-id``` endpoint.

Note: I asked the following question to professor.  I may have an additional commit or two depending on his answer.

_When implementing a query to filter an endpoint (e.g. GET /wishlists?customer-id=10) if the caller sends an invalid param value how should we handle it?  For example if customer_id is an integer and a request comes with alpha chars should we return a 200 with empty list or 400 BAD REQUEST with some message?_