### PR TITLE
Delete non existent wishlist item will now throw a 204 error code

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -235,8 +235,6 @@ def delete_addresses(wishlist_id, item_id):
     wishlist = Wishlist.find(wishlist_id)
     if wishlist:
         wishlist.delete()
-    else:
-        return make_response("", status.HTTP_404_NOT_FOUND)
 
     return make_response("", status.HTTP_204_NO_CONTENT)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -459,7 +459,7 @@ class TestWishlistServer(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_read_wishlist_item(self):
         """It should read an existing Item from an existing Wishlist"""


### PR DESCRIPTION
#64 
Any attempt to delete a non existent wishlist item will now return a 204 error code.