### PR TITLE
Bug header returned when update

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -298,7 +298,6 @@ def update_wishlist_items(wishlist_id, item_id):
     return make_response(
         jsonify(wishlist_item.serialize()),
         status.HTTP_200_OK,
-        {"Location": f"/wishlists/{wishlist.id}/items/{wishlist_item.id}"},
     )
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -545,6 +545,10 @@ class TestWishlistServer(TestCase):
         # Verify that the quantity has been updated
         self.assertEqual(data_update["quantity"], 10)
 
+        # Verify that "update wishlist item" does not return a header
+        location = resp_update.headers.get("Location", None)
+        self.assertIsNone(location)
+
     def test_update_wishlist_item_not_found(self):
         """It should not update a Wishlist Item for an item that is not found"""
         # Create a Wishlist to associate the item with


### PR DESCRIPTION
Addressed the bug #67 by

- Adding to test case to check for no "location" header when updating wishlist item
- Modified wishlist item response to not include "location" header

Passes local Green (miss 7, like last time) and Pylint.